### PR TITLE
nlp/filtering.rs: filter_nlp_messages: skip forwarded messages

### DIFF
--- a/src/modules/nlp/filtering.rs
+++ b/src/modules/nlp/filtering.rs
@@ -44,6 +44,11 @@ pub fn filter_nlp_messages(env: Arc<BotEnv>, msg: Message) -> Option<Message> {
         return None;
     }
 
+    // Skip if the message is forwarded.
+    if msg.forward().is_some() {
+        return None;
+    }
+
     // Skip messages without text or without caption
     let text = msg.text().or_else(|| msg.caption())?;
 


### PR DESCRIPTION
**I have not tested this**, just wrote this change in the GitHub UI, that's it. I'm not familiar with this codebase.

In particular, this skips messages forwarded from https://t.me/Hel_inst_bot

But in any case, that seems like a sane default behaviour, unless I missed some edge cases.

What do you think, @cofob?

Edit: noticed that there is a CI. Nice.