### PR TITLE
Add chat member and callback handlers to resident tracker module

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,7 @@ async fn run_bot(config_fpath: &OsStr) -> Result<()> {
             // should be the first handler
             .inspect(modules::tg_scraper::inspect_update)
             .inspect(modules::resident_tracker::inspect_update)
+            .branch(modules::resident_tracker::chat_member_handler())
             .branch(
                 Update::filter_message()
                     .filter(|msg: Message, env: Arc<common::BotEnv>| {
@@ -223,6 +224,7 @@ async fn run_bot(config_fpath: &OsStr) -> Result<()> {
                     .branch(modules::needs::callback_handler())
                     .branch(modules::polls::callback_handler())
                     .branch(modules::borrowed_items::callback_handler())
+                    .branch(modules::resident_tracker::callback_handler())
                     .branch(modules::butler::callback_handler())
                     .endpoint(drop_callback_query),
             )

--- a/src/modules/resident_tracker.rs
+++ b/src/modules/resident_tracker.rs
@@ -131,7 +131,7 @@ async fn handle_chat_member(
 
     let keyboard =
         InlineKeyboardMarkup::new(vec![vec![InlineKeyboardButton::callback(
-            "Stop residentship",
+            "Stop residency",
             format!("res_stop:{}", cm.new_chat_member.user.id),
         )]]);
 

--- a/src/modules/resident_tracker.rs
+++ b/src/modules/resident_tracker.rs
@@ -8,15 +8,217 @@
 use std::fmt::Write as _;
 use std::sync::Arc;
 
+use anyhow::Result;
 use diesel::dsl::count_star;
 use diesel::prelude::*;
 use teloxide::prelude::*;
-use teloxide::types::{Chat, ChatKind, ChatPublic, UpdateKind, User};
+use teloxide::types::{
+    CallbackQuery, Chat, ChatId, ChatKind, ChatPublic, InlineKeyboardButton,
+    InlineKeyboardMarkup, UpdateKind, User,
+};
 
 use crate::common::BotEnv;
 use crate::db::{DbChatId, DbUserId};
 use crate::schema;
 use crate::utils::ResultExt;
+
+/// Returns an update handler that listens for `ChatMemberUpdated` events and
+/// notifies bot admins when a resident leaves **all** residential chats.
+#[allow(clippy::missing_panics_doc)]
+pub fn chat_member_handler() -> crate::common::UpdateHandler {
+    Update::filter_chat_member()
+        // We do filtering inside the async endpoint, so no extra filter here.
+        .endpoint(handle_chat_member)
+}
+
+/// Returns an update handler that processes callback presses coming from the
+/// "Stop residentship" button.
+pub fn callback_handler() -> crate::common::UpdateHandler {
+    dptree::filter_map(filter_callbacks).endpoint(handle_callback)
+}
+
+/// Data extracted from callback query.
+#[derive(Debug, Clone)]
+struct StopResidencyQuery {
+    user_id: UserId,
+}
+
+fn filter_callbacks(callback: CallbackQuery) -> Option<StopResidencyQuery> {
+    let data = callback.data.as_ref()?;
+    let data = data.strip_prefix("res_stop:")?;
+    let user_id = data.parse::<u64>().ok()?;
+    Some(StopResidencyQuery { user_id: UserId(user_id) })
+}
+
+async fn handle_chat_member(
+    bot: Bot,
+    env: Arc<BotEnv>,
+    cm: ChatMemberUpdated,
+) -> Result<()> {
+    // Ignore bot users.
+    if cm.new_chat_member.user.is_bot {
+        return Ok(());
+    }
+
+    // Check this chat is residential.
+    if !env.config.telegram.chats.residential.contains(&cm.chat.id) {
+        return Ok(());
+    }
+
+    // Determine join/leave event.
+    let is_joined = match (
+        cm.old_chat_member.kind.is_present(),
+        cm.new_chat_member.kind.is_present(),
+    ) {
+        (false, true) => true,
+        (true, false) => false,
+        _ => return Ok(()), // promotion/demotion or no change
+    };
+
+    // We only care about leave events.
+    if is_joined {
+        return Ok(());
+    }
+
+    let user_id_db = DbUserId::from(cm.new_chat_member.user.id);
+    let residential_chat_ids = env.config.telegram.chats.residential.clone();
+
+    // Determine if the user is still seen in any residential chat and if they
+    // are currently a resident.
+    let (is_resident, is_seen) = env.transaction(|conn| {
+        let is_resident = {
+            use schema::residents::dsl as r;
+            r::residents
+                .filter(r::tg_id.eq(user_id_db))
+                .filter(r::end_date.is_null())
+                .select(count_star())
+                .get_result::<i64>(conn)?
+                > 0
+        };
+
+        let is_seen = {
+            use schema::tg_users_in_chats::dsl as t;
+            t::tg_users_in_chats
+                .filter(t::user_id.eq(user_id_db))
+                .filter(t::chat_id.eq_any(
+                    residential_chat_ids.iter().map(|&c| DbChatId::from(c)),
+                ))
+                .filter(t::seen.eq(true))
+                .select(count_star())
+                .get_result::<i64>(conn)?
+                > 0
+        };
+
+        Ok::<_, diesel::result::Error>((is_resident, is_seen))
+    })?;
+
+    // We care only about residents that are not seen in any residential chat
+    // anymore.
+    if !is_resident || is_seen {
+        return Ok(());
+    }
+
+    log::info!(
+        "User {} left all residential chats, notifying admins",
+        user_text(&cm.new_chat_member.user)
+    );
+
+    // Build notification text.
+    let text = format!(
+        "Пользователь {} вышел из всех резидентских чатов.",
+        user_text(&cm.new_chat_member.user)
+    );
+
+    let keyboard =
+        InlineKeyboardMarkup::new(vec![vec![InlineKeyboardButton::callback(
+            "Stop residentship",
+            format!("res_stop:{}", cm.new_chat_member.user.id),
+        )]]);
+
+    // Send to each admin.
+    for admin in &env.config.telegram.admins {
+        bot.send_message(ChatId::from(*admin), &text)
+            .reply_markup(keyboard.clone())
+            .await?;
+    }
+
+    Ok(())
+}
+
+async fn handle_callback(
+    bot: Bot,
+    env: Arc<BotEnv>,
+    query: StopResidencyQuery,
+    callback: CallbackQuery,
+) -> Result<()> {
+    // Check that the user pressing the button is an admin.
+    if !env.config.telegram.admins.contains(&callback.from.id) {
+        bot.answer_callback_query(&callback.id)
+            .text("You are not allowed to perform this action.")
+            .await?;
+        return Ok(());
+    }
+
+    // Close residency in DB.
+    let user_db_id = DbUserId::from(query.user_id);
+
+    let _ = env.transaction(|conn| {
+        use schema::residents::dsl as r;
+        diesel::update(r::residents)
+            .filter(r::tg_id.eq(user_db_id))
+            .filter(r::end_date.is_null())
+            .set(r::end_date.eq(diesel::dsl::now))
+            .execute(conn)
+    })?;
+
+    // Disable LDAP access (remove from residents group) if LDAP is configured.
+    if let Ok(ldap_config) = env.ldap_config() {
+        // Acquire LDAP connection.
+        let mut ldap_state = env.ldap_client().await;
+        if let Ok(ldap_conn) = ldap_state.get() {
+            // Attempt to fetch user.
+            if let Ok(Some(ldap_user)) = crate::utils::ldap::get_user(
+                ldap_conn,
+                ldap_config,
+                query.user_id,
+            )
+            .await
+            {
+                use crate::utils::ldap::{remove_user_from_group, Group};
+                let group = Group {
+                    dn: format!(
+                        "cn={},{},{}",
+                        ldap_config.attributes.resident_group,
+                        ldap_config.groups_dn,
+                        ldap_config.base_dn
+                    ),
+                    cn: ldap_config.attributes.resident_group.clone(),
+                };
+                if let Err(e) = remove_user_from_group(
+                    ldap_conn,
+                    ldap_config,
+                    &ldap_user,
+                    &group,
+                )
+                .await
+                {
+                    log::error!("Failed to remove LDAP user from group: {e}");
+                }
+            }
+        }
+    }
+
+    // Notify admin via popup and edit markup.
+    bot.answer_callback_query(&callback.id)
+        .text("Residency stopped and LDAP access disabled.")
+        .await?;
+
+    if let Some(msg) = &callback.message {
+        bot.edit_message_reply_markup(msg.chat.id, msg.id).await?;
+    }
+
+    Ok(())
+}
 
 struct Filtered<'a> {
     cm: &'a ChatMemberUpdated,
@@ -105,17 +307,16 @@ fn handle_update_transaction(
 
     match (is_resident, is_seen, f.is_joined) {
         (true, false, false) => {
-            use schema::residents::dsl as r;
+            // Previously: mark residency ended immediately.
+            // Now we defer the final decision to bot admins via a notification.
             log::info!(
-                "User {} left residential chat {}, removing from residency",
+                "User {} left residential chat {}, awaiting admin confirmation to stop residency",
                 user_text(&f.cm.new_chat_member.user),
                 chat_text(&f.cm.chat),
             );
-            diesel::update(r::residents)
-                .filter(r::tg_id.eq(user_id))
-                .filter(r::end_date.is_null())
-                .set(r::end_date.eq(diesel::dsl::now))
-                .execute(conn)?;
+            // No DB changes here. A separate async handler will notify admins
+            // and apply the changes once the "Stop residentship" button is
+            // pressed.
         }
         (false, true, true) => {
             // Add to residency


### PR DESCRIPTION
- Introduced `chat_member_handler` to notify admins when a resident leaves all residential chats.
- Added `callback_handler` to process "Stop residentship" button presses.
- Updated `main.rs` to include new handlers in the bot's update processing branches.
- Refactored residency handling to defer database updates until admin confirmation via callback.