### PR TITLE
Remove execute_command function and replace it with separate functions

### DIFF
--- a/src/modules/nlp/types.rs
+++ b/src/modules/nlp/types.rs
@@ -25,10 +25,11 @@ pub struct RemoveMemoryArgs {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ExecuteCommandArgs {
-    pub command: String,
-    #[serde(default)]
-    pub arguments: Option<String>,
+pub struct NothingArgs {}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AddNeedArgs {
+    pub item: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
- Replaced the `handle_execute_command` function with specific handlers for each command: `handle_status_command`, `handle_needs_command`, `handle_add_need_command`, and `handle_open_door_command`.
- Updated command argument types to enhance clarity and enforce structure, introducing `NothingArgs` and `AddNeedArgs`.
- Modified the command processing logic to directly call the new handlers based on user requests, improving maintainability and readability.
- Updated documentation to reflect changes in available functions and their usage.